### PR TITLE
chore: auto-inject GH_PAT_DRYVIST via direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,12 @@
+# Auto-inject GH_PAT_DRYVIST from the elevate-access keychain so gh CLI
+# (and any subprocess, including `claude`) authenticates against the
+# dryvist org without per-command token prefixing. Skips silently if the
+# keychain item isn't present (e.g. on a different machine or CI).
+_gh_pat_dryvist="$(security find-generic-password \
+  -s GH_PAT_DRYVIST -a ai-cli-coder \
+  -w ~/Library/Keychains/elevate-access.keychain-db 2>/dev/null || true)"
+if [ -n "$_gh_pat_dryvist" ]; then
+  export GH_TOKEN="$_gh_pat_dryvist"
+  export GITHUB_TOKEN="$_gh_pat_dryvist"
+fi
+unset _gh_pat_dryvist

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 # Editor / OS
 .idea/
 .vscode/
+
+# direnv cache
+.direnv/


### PR DESCRIPTION
## Summary

Adds an \`.envrc\` to the pack template so any pack scaffolded from it inherits a working \`gh\` CLI session against the dryvist org. Mirrors the established \`nix-screenpipe\` pattern.

## How it works

- Reads \`GH_PAT_DRYVIST\` from the \`elevate-access\` keychain (account: \`ai-cli-coder\`)
- Exports \`GH_TOKEN\` and \`GITHUB_TOKEN\` for the worktree
- Silent skip if the keychain item is absent (CI / portable across machines)

## Per-pack flow

\`\`\`sh
gh repo create --template dryvist/cc-edge-pack-template dryvist/<new-pack>
gh repo clone dryvist/<new-pack>
cd <new-pack>
direnv allow   # one-time
\`\`\`

After that, \`gh\` works without \`GH_TOKEN=\$(security find-...)\` wrapping in every command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)