### PR TITLE
feat(tests): behavioral test extensions — route flow + required-fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ The single most important rule: **distinguish generic files from pack-specific f
 - `tests/test_pipelines.py`
 - `tests/test_routes.py`
 - `tests/requirements.txt`
+- `pyrightconfig.json`
 - `Makefile`
 - `docker-compose.yml`
 - `.github/workflows/test.yml` (only the `pack_type:` value changes per pack)
@@ -35,6 +36,7 @@ If you find yourself wanting to modify any of the above in a pack repo, **stop**
 - `default/samples.yml` (sample catalog)
 - `data/samples/*.json` (sample events)
 - `tests/fixtures/<pipeline>/*.json` (test fixtures)
+- `tests/fixtures/.skip-required-fields` (optional marker — opts the pack out of the required-fields assertion when output sourcetype/index are intentionally set downstream rather than in-pack)
 - `README.md` (describe your specific pack)
 - `LICENSE` (use Apache-2.0 unless instructed otherwise)
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,6 @@
+{
+  "venvPath": ".",
+  "venv": ".venv",
+  "include": ["tests"],
+  "pythonVersion": "3.12"
+}

--- a/tests/cribl_client.py
+++ b/tests/cribl_client.py
@@ -12,7 +12,9 @@ References:
 from __future__ import annotations
 
 import io
+import json
 import os
+import re
 import tarfile
 import time
 import uuid
@@ -22,6 +24,28 @@ from typing import Any
 
 import ndjson
 import requests
+import yaml
+
+# Locate the pack root (one level up from tests/) so client helpers can read
+# package.json and route.yml without each caller passing the path in.
+PACK_ROOT = Path(__file__).resolve().parent.parent
+
+# Canonical Cribl filter shape we can auto-resolve: `<field>=='<value>'`.
+# Anything more complex (boolean ops, function calls, regex) is out of scope
+# for the local evaluator — callers should pytest.skip when this returns None.
+_SIMPLE_FILTER_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*==\s*['\"](.*?)['\"]\s*$")
+
+
+def _parse_simple_filter(expr: str) -> tuple[str, str] | None:
+    """Parse `<field>=='<value>'` (or `=="value"`) into (field, value).
+
+    Returns None for any expression we cannot statically resolve. Tests should
+    pytest.skip when None is returned so complex filters don't block the suite.
+    """
+    match = _SIMPLE_FILTER_RE.match(expr or "")
+    if not match:
+        return None
+    return match.group(1), match.group(2)
 
 
 class CriblClient:
@@ -256,3 +280,145 @@ class CriblClient:
         if isinstance(response, dict):
             return response.get("items", [])
         return response or []
+
+    # ---- Route flow + assertions ------------------------------------------
+
+    def run_route_flow(
+        self,
+        sample_id: str,
+        events: list[dict],
+        pack: str | None = None,
+    ) -> dict:
+        """Match events against route.yml filters, then execute the matched pipeline.
+
+        Cribl's `/preview` API has no `mode: "route"` — this is the local
+        fallback. Loads `PACK_ROOT/default/pipelines/route.yml`, evaluates each
+        non-disabled route's filter against the supplied events using the
+        canonical `<field>=='<value>'` matcher, and on the first match calls
+        `run_pipeline()` for that route's pipeline.
+
+        Returns:
+            {"route": <route dict>, "pipeline": <pipeline id>, "events": [...]}
+
+        Raises:
+            ValueError: if no route matches. The error lists any filters that
+                were skipped because the local matcher doesn't support them, so
+                the caller can decide whether to treat the situation as a
+                pytest.skip vs a real failure.
+        """
+        route_yml = PACK_ROOT / "default" / "pipelines" / "route.yml"
+        config = yaml.safe_load(route_yml.read_text())
+
+        skipped_filters: list[str] = []
+        for route in config.get("routes", []):
+            if route.get("disabled"):
+                continue
+            parsed = _parse_simple_filter(route.get("filter", ""))
+            if parsed is None:
+                skipped_filters.append(route.get("filter", ""))
+                continue
+            field, expected_value = parsed
+            if any(event.get(field) == expected_value for event in events):
+                output = self.run_pipeline(route["pipeline"], sample_id, pack=pack)
+                return {
+                    "route": route,
+                    "pipeline": route["pipeline"],
+                    "events": output,
+                }
+
+        raise ValueError(
+            "No matching route for given events. "
+            f"Filters skipped (unparseable by local matcher): {skipped_filters}"
+        )
+
+    def assert_required_fields(
+        self,
+        events: list[dict],
+        pack_type: str | None = None,
+    ) -> None:
+        """Assert every event has the canonical output fields for its pack type.
+
+        Edge packs require `sourcetype` + `index` (Splunk-canonical routing
+        fields). Stream packs require `host` + `source` + `_time`.
+
+        When `pack_type` is None, infer it from `package.json` name prefix
+        (`cc-edge-` -> edge, `cc-stream-` -> stream). Tests can override by
+        passing pack_type explicitly.
+        """
+        if pack_type is None:
+            pack_type = _detect_pack_type()
+        if pack_type == "edge":
+            required: tuple[str, ...] = ("sourcetype", "index")
+        elif pack_type == "stream":
+            required = ("host", "source", "_time")
+        else:
+            raise ValueError(
+                f"Unknown pack_type {pack_type!r} (expected 'edge' or 'stream')"
+            )
+
+        violations: list[str] = []
+        for i, event in enumerate(events):
+            missing = [k for k in required if k not in event]
+            if missing:
+                violations.append(f"event {i}: missing {missing}")
+
+        assert not violations, (
+            f"{pack_type.title()} pack required fields {required} missing from "
+            f"{len(violations)}/{len(events)} event(s):\n  "
+            + "\n  ".join(violations)
+        )
+
+    # ---- Live capture ------------------------------------------------------
+    #
+    # Two-phase async API. start_capture() returns a capture id immediately;
+    # read_capture() polls until the session reports complete. These primitives
+    # exist to support future integration tests that publish into a live source
+    # and assert routes fire — Phase A's unit tests don't exercise them.
+
+    def start_capture(
+        self,
+        filter_expr: str,
+        max_events: int = 100,
+        timeout_ms: int = 30000,
+    ) -> str:
+        """Start an async capture matching `filter_expr`. Returns the capture id."""
+        payload = {
+            "filter": filter_expr,
+            "maxEvents": max_events,
+            "timeout": timeout_ms,
+            "level": 0,
+        }
+        response = self._call("post", "/lib/captures", payload=payload)
+        if not isinstance(response, dict) or "captureId" not in response:
+            raise RuntimeError(f"Unexpected capture response: {response!r}")
+        return response["captureId"]
+
+    def read_capture(
+        self,
+        capture_id: str,
+        poll_interval: float = 1.0,
+        timeout_seconds: int = 60,
+    ) -> list[dict]:
+        """Poll the capture session until status=='complete', returning events."""
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            response = self._call("get", f"/lib/captures/{capture_id}/events")
+            if isinstance(response, dict) and response.get("status") == "complete":
+                return response.get("items", [])
+            time.sleep(poll_interval)
+        raise TimeoutError(
+            f"Capture {capture_id} did not complete in {timeout_seconds}s"
+        )
+
+
+def _detect_pack_type() -> str:
+    """Infer pack_type ('edge' or 'stream') from package.json name."""
+    name = json.loads((PACK_ROOT / "package.json").read_text()).get("name", "")
+    if name.startswith("cc-edge-"):
+        return "edge"
+    if name.startswith("cc-stream-"):
+        return "stream"
+    raise ValueError(
+        f"Cannot detect pack_type from package.json name {name!r}; "
+        "expected 'cc-edge-<source>-io' or 'cc-stream-<source>-io' prefix."
+    )

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -4,6 +4,9 @@ Pipeline tests — generic, parametrized over tests/fixtures/.
 Convention:
     tests/fixtures/<pipeline-name>/<case>.json          -- input event(s)
     tests/fixtures/<pipeline-name>/<case>.expected.json -- (optional) expected output
+    tests/fixtures/.skip-required-fields                -- (optional) marker;
+        when present, the required-fields assertion is bypassed for this pack
+        (use for pass-through packs whose downstream sets sourcetype/index).
 
 For each fixture:
 1. Save the input as a Cribl sample.
@@ -11,6 +14,9 @@ For each fixture:
 3. If <case>.expected.json exists, partial-match-assert each output event has
    the expected fields and values. Extra fields in actual output are allowed.
 4. If <case>.expected.json is absent, smoke-test only: assert non-empty output.
+5. Unless `.skip-required-fields` is present, assert every output event has
+   the canonical fields for this pack type (Edge: sourcetype + index;
+   Stream: host + source + _time).
 
 This file is GENERIC — copied verbatim from the template into every pack repo.
 Pack-specific behavior is expressed entirely through fixture data.
@@ -24,6 +30,7 @@ from pathlib import Path
 import pytest
 
 FIXTURES = Path(__file__).parent / "fixtures"
+SKIP_REQUIRED_FIELDS_MARKER = FIXTURES / ".skip-required-fields"
 
 
 def _discover_cases() -> list:
@@ -92,10 +99,11 @@ def test_pipeline_processes_sample(
             "Check the pipeline's filter/drop conditions."
         )
 
-        if expected_file is None:
-            return  # Smoke-test only
+        if expected_file is not None:
+            expected = _load_events(expected_file)
+            _assert_partial_match(result, expected, context=input_file.name)
 
-        expected = _load_events(expected_file)
-        _assert_partial_match(result, expected, context=input_file.name)
+        if not SKIP_REQUIRED_FIELDS_MARKER.exists():
+            cribl.assert_required_fields(result)
     finally:
         cribl.delete_sample(sample_id)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,14 +8,19 @@ Validates:
 - every referenced pipeline has a default/pipelines/<name>/conf.yml
 - every route uses 'output: __group' (vct-cribl-pack-validator rule)
 - no route filter is statically falsy (would never match)
+- (dynamic) for each route with an auto-resolvable filter, a synthetic event
+  matching that filter triggers the named pipeline and isn't dropped
 """
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
 import yaml
+
+from cribl_client import _parse_simple_filter
 
 PACK_ROOT = Path(__file__).parent.parent
 ROUTE_YML = PACK_ROOT / "default" / "pipelines" / "route.yml"
@@ -25,6 +30,21 @@ PIPELINES_DIR = PACK_ROOT / "default" / "pipelines"
 def _load_routes() -> dict:
     with open(ROUTE_YML) as fh:
         return yaml.safe_load(fh)
+
+
+def _routes_for_param() -> list:
+    """Parametrize one entry per non-disabled route, keyed by route id."""
+    if not ROUTE_YML.exists():
+        return []
+    config = yaml.safe_load(ROUTE_YML.read_text()) or {}
+    return [
+        pytest.param(route, id=route.get("id", f"route-{i}"))
+        for i, route in enumerate(config.get("routes", []))
+        if not route.get("disabled")
+    ]
+
+
+ROUTES = _routes_for_param()
 
 
 def test_route_yml_exists() -> None:
@@ -89,3 +109,43 @@ def test_no_pipeline_named_main() -> None:
             f"Route '{route.get('id')}' uses pipeline 'main'. "
             "Per validator rule, pipelines must have descriptive names."
         )
+
+
+@pytest.mark.skipif(
+    not ROUTES,
+    reason="No routes declared in default/pipelines/route.yml",
+)
+@pytest.mark.parametrize("route", ROUTES)
+def test_route_flow_executes_pipeline(cribl, pack_id: str, route: dict) -> None:
+    """Fabricate a matching event, route it, and assert the pipeline executed.
+
+    Skips routes whose filter the local matcher cannot resolve — those need
+    integration-level testing rather than this unit-level synthetic-event flow.
+    """
+    parsed = _parse_simple_filter(route.get("filter", ""))
+    if parsed is None:
+        pytest.skip(
+            f"Route '{route.get('id')}' filter '{route.get('filter')!r}' "
+            "is not auto-resolvable by the local matcher (expected `<field>=='<value>'`)."
+        )
+    assert parsed is not None  # for type narrowing — pytest.skip raised above
+    field, value = parsed
+    event = {
+        field: value,
+        "_raw": "{}",
+        "_time": time.time(),
+    }
+    sample_id = cribl.save_sample(f"route-flow-{route.get('id')}", [event])
+    try:
+        result = cribl.run_route_flow(sample_id, [event], pack=pack_id)
+        assert result["route"].get("id") == route.get("id"), (
+            f"Expected route '{route.get('id')}' to match the synthetic event, "
+            f"but route '{result['route'].get('id')}' matched first."
+        )
+        assert result["events"], (
+            f"Pipeline '{result['pipeline']}' produced no output for the "
+            f"synthetic event matching route '{route.get('id')}' "
+            "— check the pipeline for unconditional Drop functions."
+        )
+    finally:
+        cribl.delete_sample(sample_id)


### PR DESCRIPTION
## Summary

Turns the template's pack-test harness from *structural* checks into *behavioral* ones — the harness now proves that routes resolve to the right pipelines and that output events meet the Splunk-canonical required-fields contract.

### CriblClient primitives (`tests/cribl_client.py`)

- **`run_route_flow(sample_id, events, pack=None)`** — local fallback for the unsupported `mode: \"route\"` preview API. Parses `default/pipelines/route.yml`, evaluates each non-disabled route's filter via `_parse_simple_filter` (canonical `<field>=='<value>'` matcher), and on first match calls `run_pipeline` for that route's pipeline. Returns `{route, pipeline, events}`.
- **`assert_required_fields(events, pack_type=None)`** — Edge requires `sourcetype` + `index`; Stream requires `host` + `source` + `_time`. `pack_type` auto-detected from `package.json` name prefix.
- **`start_capture` / `read_capture`** — two-phase wrappers around `/api/v1/lib/captures` (POST start, GET poll until `status==complete`). Primitives reserved for future integration tests that publish into a live source; this PR's unit suite doesn't exercise them.

### Tests

- **`test_routes.py::test_route_flow_executes_pipeline`** — parametrized over routes; for each, fabricates a matching synthetic event, runs it through `run_route_flow`, and asserts the right pipeline executed and produced output. Routes with unparseable filters get `pytest.skip` cleanly.
- **`test_pipelines.py::test_pipeline_processes_sample`** — after the optional partial-match block, calls `assert_required_fields` on the output. Suppressed via `tests/fixtures/.skip-required-fields` marker (escape hatch for pass-through packs whose downstream sets the fields).

### Tooling

- `pyrightconfig.json` points the LSP at `.venv` so scaffolded packs get correct import resolution without per-developer IDE setup.
- `CLAUDE.md` updated: `pyrightconfig.json` listed as generic; `.skip-required-fields` documented as the per-pack escape hatch.

## Test plan

- [x] `make install` succeeds (creates `.venv` with PyYAML + ndjson + requests + pytest)
- [x] `pytest --collect-only` collects all 9 tests including the new `test_route_flow_executes_pipeline`
- [x] `_parse_simple_filter(\"datatype=='claude-code-otel'\")` returns `('datatype', 'claude-code-otel')`
- [x] No new lint/type diagnostics
- [ ] **Sample-consumer verification** (manual): a throwaway draft PR on `dryvist/cc-edge-claude-code-io` that copies these `tests/` files into the pilot (no fixtures, no Eval changes) shows green CI. Validates the new code doesn't regress an existing pack's harness.

The template's own CI mostly skips because of `if: github.event.repository.is_template == false`. The `validate` job still runs.