### PR TITLE
fix(ci): correct dcarbone/install-yq-action version (v1.3.1)

### DIFF
--- a/.github/workflows/cribl-pack-test.yml
+++ b/.github/workflows/cribl-pack-test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install yq (pinned)
-        uses: dcarbone/install-yq-action@v1.4.4
+        uses: dcarbone/install-yq-action@v1.3.1
         with:
           version: v${{ inputs.yq_version }}
 


### PR DESCRIPTION
v1.4.4 doesn't exist; latest is v1.3.1. Pilot CI failed on this in dryvist/cc-edge-claude-code-io#4.