### PR TITLE
fix(ci): pass .yamllint.yml as config_file

### DIFF
--- a/.github/workflows/cribl-pack-test.yml
+++ b/.github/workflows/cribl-pack-test.yml
@@ -46,10 +46,11 @@ jobs:
         with:
           version: v${{ inputs.yq_version }}
 
-      - name: Lint YAML (uses .yamllint.yml from pack root if present)
+      - name: Lint YAML
         uses: frenck/action-yamllint@v1.5.0
         with:
           path: default/
+          config_file: .yamllint.yml
 
       - name: Validate pack structure
         run: ./scripts/validate-pack-structure.sh


### PR DESCRIPTION
yamllint action wasn't picking up our config; explicitly point it at the pack-root .yamllint.yml. Pilot CI failing on this.