### PR TITLE
feat: ship working demo passthrough pipeline + prove harness teeth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ permissions:
 
 jobs:
   test:
-    # Skip on the template repo itself; consumer repos have is_template: false.
-    if: github.event.repository.is_template == false
+    # Runs on the template too — the template now ships a working demo
+    # passthrough pipeline + fixture so the harness gets exercised here
+    # before consumer repos inherit it.
     uses: dryvist/cc-edge-pack-template/.github/workflows/cribl-pack-test.yml@main
     with:
       # CHANGE per pack: 'edge' for Cribl Edge packs, 'stream' for Cribl Stream packs.

--- a/default/pipelines/passthrough/conf.yml
+++ b/default/pipelines/passthrough/conf.yml
@@ -1,0 +1,20 @@
+output: default
+streamtags: []
+groups: {}
+asyncFuncTimeout: 1000
+description: >-
+  Demo passthrough pipeline. Stamps Splunk-canonical fields
+  (sourcetype, index, datatype) on every event. Replace this
+  with your real pipeline logic when scaffolding a new pack.
+functions:
+  - id: eval
+    filter: "true"
+    disabled: false
+    conf:
+      add:
+        - name: sourcetype
+          value: "'cribl:demo'"
+        - name: index
+          value: "'main'"
+        - name: datatype
+          value: "'cribl-demo'"

--- a/default/pipelines/route.yml
+++ b/default/pipelines/route.yml
@@ -2,19 +2,19 @@ id: default
 groups: {}
 comments: []
 routes:
-  # Replace this placeholder route with your real routes.
+  # Demo route. Replace with your real routes when scaffolding a new pack.
   # Validator rules:
   #   - id and pipeline must be descriptive (no 'main', no 'route1')
   #   - filter must be a real expression (not literally 'false' / '0')
   #   - output MUST be __group (not input_id)
-  - id: REPLACE_ROUTE_ID
-    name: Replace With Route Name
+  - id: passthrough
+    name: Demo Passthrough
     final: true
     disabled: false
-    pipeline: REPLACE_PIPELINE_NAME
-    description: "Placeholder — replace id, name, pipeline, and filter."
+    pipeline: passthrough
+    description: "Demo route — replace when scaffolding a new pack."
     enableOutputExpression: false
     targetContext: group
-    filter: "datatype=='replace-with-your-datatype'"
+    filter: "datatype=='cribl-demo'"
     clones: []
     output: __group

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "REPLACE-WITH-PACK-NAME",
+  "name": "cc-edge-demo-io",
   "version": "0.0.1",
   "minLogStreamVersion": "4.17.0",
-  "author": "Your Name <your.email@example.com>",
-  "description": "REPLACE: Brief description of what this pack does.",
-  "displayName": "REPLACE With Display Name",
+  "author": "dryvist <hello@dryvist.example>",
+  "description": "Demo passthrough pack — replace name/displayName/description/author when scaffolding from this template.",
+  "displayName": "Cribl Edge Demo Pack",
   "tags": {
     "streamtags": [
       "replace",

--- a/tests/fixtures/passthrough/sample.expected.json
+++ b/tests/fixtures/passthrough/sample.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "sourcetype": "cribl:demo",
+    "sourcetype": "cribl:WRONG-VALUE-FOR-TEETH-TEST",
     "index": "main",
     "datatype": "cribl-demo",
     "_raw": "demo event"

--- a/tests/fixtures/passthrough/sample.expected.json
+++ b/tests/fixtures/passthrough/sample.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "sourcetype": "cribl:WRONG-VALUE-FOR-TEETH-TEST",
+    "sourcetype": "cribl:demo",
     "index": "main",
     "datatype": "cribl-demo",
     "_raw": "demo event"

--- a/tests/fixtures/passthrough/sample.expected.json
+++ b/tests/fixtures/passthrough/sample.expected.json
@@ -1,0 +1,8 @@
+[
+  {
+    "sourcetype": "cribl:demo",
+    "index": "main",
+    "datatype": "cribl-demo",
+    "_raw": "demo event"
+  }
+]

--- a/tests/fixtures/passthrough/sample.json
+++ b/tests/fixtures/passthrough/sample.json
@@ -1,0 +1,7 @@
+[
+  {
+    "_raw": "demo event",
+    "_time": 1714137600,
+    "datatype": "cribl-demo"
+  }
+]


### PR DESCRIPTION
## Why

The template's test workflow has been guarded by `if: github.event.repository.is_template == false`, which means **every CI run on template main has been a no-op skip** — including the merges of PRs #4–#7 that introduced the TS harness. The harness has never actually executed on this repo.

This PR fixes that by:

1. Replacing the `REPLACE_*` placeholder route + (missing) pipeline conf with a real working demo (a passthrough that stamps `sourcetype` / `index` / `datatype` on every event).
2. Adding a fixture pair that drives the auto-discovered Vitest case.
3. Lifting the `is_template == false` guard so CI runs end-to-end against the demo content on every template push/PR.

## What this proves

After this lands, the template ships a known-good baseline:

- `validate` job: structural checks against real (not placeholder) pack files.
- `test` job: full Vitest run against a live Cribl container, with the demo fixture exercising both `pipelines.test.ts` (partial-match assertion + required-fields check) and `routes.test.ts` (dynamic route flow against the synthetic event).

I'll deliberately break the expected fixture in a follow-up push on this branch to confirm CI fails with a useful diff, then restore before merging — receipts that the harness has teeth, not just that it exits 0 against its own output.

## Demo content can be replaced freely

When a consumer scaffolds from this template via `gh repo create --template`, they inherit:

- `default/pipelines/passthrough/` — replace with their pipelines
- `default/pipelines/route.yml` — replace with their routes
- `tests/fixtures/passthrough/` — replace with their fixtures

Names are intentionally generic so it's obvious they're demo content.