### PR TITLE
feat(fixtures): replace toy passthrough sample with Claude/Gemini/Codex shapes

### DIFF
--- a/tests/fixtures/passthrough/claude-code.expected.json
+++ b/tests/fixtures/passthrough/claude-code.expected.json
@@ -1,0 +1,9 @@
+[
+  {
+    "sourcetype": "cribl:demo",
+    "index": "main",
+    "datatype": "cribl-demo",
+    "type": "assistant",
+    "sessionId": "fe82a754-0606-4bcf-b79a-f7b6f2a72bc8"
+  }
+]

--- a/tests/fixtures/passthrough/claude-code.json
+++ b/tests/fixtures/passthrough/claude-code.json
@@ -1,0 +1,22 @@
+[
+  {
+    "datatype": "cribl-demo",
+    "_time": 1736836313.996,
+    "type": "assistant",
+    "sessionId": "fe82a754-0606-4bcf-b79a-f7b6f2a72bc8",
+    "message": {
+      "role": "assistant",
+      "model": "claude-opus-4-5-20251101",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_abc",
+          "name": "Read",
+          "input": { "file_path": "/src/app.ts" }
+        }
+      ],
+      "stop_reason": "tool_use",
+      "usage": { "input_tokens": 1234, "output_tokens": 567 }
+    }
+  }
+]

--- a/tests/fixtures/passthrough/codex.expected.json
+++ b/tests/fixtures/passthrough/codex.expected.json
@@ -1,0 +1,10 @@
+[
+  {
+    "sourcetype": "cribl:demo",
+    "index": "main",
+    "datatype": "cribl-demo",
+    "type": "item.tool.result",
+    "sessionId": "rollout-019ddfce-b73e-7230-ae24-a70b89c76982",
+    "tool": "exec_command"
+  }
+]

--- a/tests/fixtures/passthrough/codex.json
+++ b/tests/fixtures/passthrough/codex.json
@@ -1,0 +1,12 @@
+[
+  {
+    "datatype": "cribl-demo",
+    "_time": 1736850010,
+    "type": "item.tool.result",
+    "sessionId": "rollout-019ddfce-b73e-7230-ae24-a70b89c76982",
+    "turnId": "turn_001",
+    "tool": "exec_command",
+    "input": { "command": "grep -n 'def' api.py" },
+    "output": "1: def get_user(id):\n5: def handle_error():"
+  }
+]

--- a/tests/fixtures/passthrough/gemini.expected.json
+++ b/tests/fixtures/passthrough/gemini.expected.json
@@ -3,6 +3,8 @@
     "sourcetype": "cribl:demo",
     "index": "main",
     "datatype": "cribl-demo",
-    "_raw": "demo event"
+    "type": "user",
+    "sessionId": "sess-abc123",
+    "projectHash": "proj-hash-xyz"
   }
 ]

--- a/tests/fixtures/passthrough/gemini.json
+++ b/tests/fixtures/passthrough/gemini.json
@@ -1,0 +1,12 @@
+[
+  {
+    "datatype": "cribl-demo",
+    "_time": 1736850000,
+    "type": "user",
+    "id": "msg_1",
+    "sessionId": "sess-abc123",
+    "projectHash": "proj-hash-xyz",
+    "model": "gemini-2.0-flash",
+    "content": [{ "text": "Implement auth middleware" }]
+  }
+]

--- a/tests/fixtures/passthrough/sample.json
+++ b/tests/fixtures/passthrough/sample.json
@@ -1,7 +1,0 @@
-[
-  {
-    "_raw": "demo event",
-    "_time": 1714137600,
-    "datatype": "cribl-demo"
-  }
-]


### PR DESCRIPTION
## Summary

Replaces the toy `sample.json` fixture with three vendor-shaped fixtures
(Claude Code, Gemini, Codex) that exercise the live `cribl/cribl` preview
API through the existing `pipelines.test.ts` auto-discovery. **No pipeline,
route, test-code, workflow, or doc changes** — the harness shape is
unchanged; this is the demo-data buildout the AGENTS.md / docs already
promised.

This is the second of two PRs proving the template runs end-to-end:
- #10 (merged) synced docs + adopted the AGENTS.md / `@AGENTS.md` pattern.
- This PR proves the harness actually executes against a containerized
  Cribl Edge instance with realistic-shaped vendor input.

## Fixtures

Each fixture keeps `datatype: 'cribl-demo'` so the existing route filter
still matches; each `.expected.json` partial-matches the three Eval-stamped
fields (`sourcetype`, `index`, `datatype`) plus one or two distinctive
input fields per vendor.

| File | Shape highlight |
|---|---|
| `tests/fixtures/passthrough/claude-code.json` | Nested `message.content[]` with polymorphic `tool_use` entry, inline `usage` accounting, UUID `sessionId` |
| `tests/fixtures/passthrough/gemini.json` | Flat with `type` discriminator + `projectHash` + `content[].text` |
| `tests/fixtures/passthrough/codex.json` | Turn-scoped `item.tool.result` with `rollout-<uuid>` session + discrete `tool` field |

Shape sources (plausible-looking, not byte-canonical — the demo's job is to
exercise heterogeneous JSON through the live pipeline, not parse production
vendor output):

- Claude Code: https://code.claude.com/docs/en/agent-sdk/session-storage
- Gemini CLI: https://github.com/google-gemini/gemini-cli/issues/15292
- Codex CLI: https://developers.openai.com/codex/cli/reference

## Workflow validation

This PR's CI run **is** the validation:

- Touches `tests/**` → `test.yml`'s path filter triggers
  `cribl-pack-test.yml` → `validate-pack-structure.sh` + Vitest against the
  live `cribl/cribl` service container. Green CI = test.yml +
  cribl-pack-test.yml + global-setup + pack install + pipeline execution
  all proven end-to-end.
- `release-please.yml` and `release.yml` are intentionally gated off on the
  template (`is_template == false` guard + `v*` tag-only trigger). Their
  full execution path is validated the first time a downstream pack
  (e.g. `cc-edge-claude-code-io`) merges a `feat:` to main and merges the
  resulting release PR. **Not actionable in this repo.**

## Mirror-readiness

A downstream `cc-edge-<vendor>-io` pack that scaffolds from this template
swaps:

1. The fixture content (drop in real vendor logs)
2. The route filter in `default/pipelines/route.yml`
3. The Eval `sourcetype`/`index` values in
   `default/pipelines/passthrough/conf.yml`

…and gets a working CI-validated pack with zero test-code edits. Per the
"After scaffolding" section in the README.

## Test plan

- [x] `pnpm run lint` (Biome) — clean
- [x] `pnpm run typecheck` — clean
- [x] All six JSON files parse with `JSON.parse`
- [ ] **Local `make docker-up && make test`** — couldn't run in this
  sandbox (no Docker daemon). Relying on CI for the live container run.
- [ ] **CI `cribl-pack-test.yml` green** — this PR's `test.yml` run

https://claude.ai/code/session_01W79ngAnJY1uRwMnTAEhBKH

---
_Generated by [Claude Code](https://claude.ai/code/session_01W79ngAnJY1uRwMnTAEhBKH)_