### PR TITLE
fix(ci): cc-edge-pack-template — retarget reusable-workflow owner refs to current org homes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,6 @@
 name: release-please
 
-# Inherits the canonical release-please pipeline from JacobPEvans/.github,
+# Inherits the canonical release-please pipeline from JacobPEvans-personal/.github,
 # which enforces the org-wide major-bump block and uses the GitHub App token
 # so release-please PRs trigger downstream workflows. See
 # dryvist/.github/CLAUDE.md for the inheritance chain.
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release-please:
     if: github.event.repository.is_template == false
-    uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
+    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
     # The inherited workflow's input is named GH_ACTION_JACOBPEVANS_APP_ID for
     # historical reasons. dryvist exposes a generic GH_APP_ID org secret and
     # forwards it here at the boundary — repo readers only see the generic name.


### PR DESCRIPTION
## Root cause

`JacobPEvans/.github` moved to `JacobPEvans-personal/.github` as part of the org account migration. GitHub Actions `uses:` references do not follow repo transfer/rename redirects and cannot use variables — the literal owner in the YAML must match the current location or the workflow fails at parse time.

## Change

`.github/workflows/release-please.yml`: `uses: JacobPEvans/.github/...` → `uses: JacobPEvans-personal/.github/...` (both the functional `uses:` line and the adjacent comment that named the old path).

## Context

Part of an org-wide sweep correcting `uses:` owner references after the `JacobPEvans` → `JacobPEvans-personal` account rename. This is a **template repo** — fixing it keeps repos generated from it correct going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)