### PR TITLE
chore(renovate): onboard to org entry-point preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>dryvist/.github"]
+}


### PR DESCRIPTION
Adds a pointer renovate.json extending local>dryvist/.github so this repo inherits the central org Renovate config and Mend onboards it.

Refs: dryvist/terraform-github#6

Part of org-wide Renovate centralization (terraform-github#6).