### PR TITLE
style(biome): mirror canonical json expand=always (keep arrays one-per-line)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -17,9 +17,22 @@
       "!**/tests/fixtures"
     ]
   },
-  "formatter": { "enabled": true, "useEditorconfig": true },
-  "linter": { "enabled": true },
+  "formatter": {
+    "enabled": true,
+    "useEditorconfig": true
+  },
+  "linter": {
+    "enabled": true
+  },
   "json": {
+    "formatter": {
+      "trailingCommas": "none",
+      // Keep arrays/objects one-item-per-line. Biome 2.4+ changed the `expand`
+      // default to collapse primitive arrays that fit lineWidth; "always" restores
+      // the readable, greppable, clean-diff style the org config files relied on.
+      // Mirrors dryvist/.github/biome.jsonc.
+      "expand": "always"
+    },
     "parser": {
       "allowComments": true,
       "allowTrailingCommas": true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,9 @@
     ".": {
       "package-name": "cc-edge-pack-template",
       "changelog-path": "CHANGELOG.md",
-      "extra-files": ["package.json"]
+      "extra-files": [
+        "package.json"
+      ]
     }
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>dryvist/.github"]
+  "extends": [
+    "local>dryvist/.github"
+  ]
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -15,9 +15,19 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
-    "lib": ["ES2022"],
-    "types": ["node"]
+    "lib": [
+      "ES2022"
+    ],
+    "types": [
+      "node"
+    ]
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist", "fixtures"]
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "fixtures"
+  ]
 }


### PR DESCRIPTION
## Summary

Biome 2.4+ changed the formatter's `expand` default: `auto` now collapses primitive arrays that fit within `lineWidth` onto a single line. This repo's `biome.jsonc` (a mirror of `dryvist/.github`) had **no `json.formatter` block**, so it would inherit that collapse the moment it runs under a current Biome — turning readable one-item-per-line config into dense single-line arrays.

This mirrors the canonical fix in `dryvist/.github`: pin `json.formatter.expand: "always"` and reformat JSON so the committed files stay expanded.

## Scope

- **JSON only.** TS style is intentionally **not** touched — this does not adopt canonical's `lineWidth: 120` or JS quote settings (that would be a separate, deliberate restyle).
- Files reformatted: `biome.jsonc`, `release-please-config.json`, `renovate.json`, `tests/tsconfig.json` — all pure array/object expansion.

## Test plan

- [x] `npx @biomejs/biome format .` is clean after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)