### PR TITLE
ci: re-enable zizmor gate and SHA-pin third-party actions

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -34,9 +34,6 @@ jobs:
     with:
       markdown_lint: true
       file_size: true
-      # Staged: pre-existing workflow-security findings tracked in #33;
-      # enable once resolved.
-      zizmor: false
       filters: |
         markdown:
           - '**.md'

--- a/.github/workflows/cribl-pack-test.yml
+++ b/.github/workflows/cribl-pack-test.yml
@@ -47,12 +47,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install yq (pinned)
-        uses: dcarbone/install-yq-action@v1.3.1
+        uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
         with:
           version: v${{ inputs.yq_version }}
 
       - name: Lint YAML
-        uses: frenck/action-yamllint@v1.5.0
+        uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47 # v1.5.0
         with:
           path: default/
           config_file: .yamllint.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 11.11.0
           run_install: false
@@ -116,7 +116,7 @@ jobs:
         run: pnpm run typecheck
 
       - name: Wait for Cribl health endpoint
-        uses: iFaxity/wait-on-action@v1.2.1
+        uses: iFaxity/wait-on-action@a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866 # v1.2.1
         with:
           resource: http://localhost:9000/api/v1/health
           timeout: 120000


### PR DESCRIPTION
## Related Issues
Closes #33

## Summary
Re-enables the zizmor workflow-security gate after SHA-pinning the four blocking third-party actions.

## Changes
- `cribl-pack-test.yml`: SHA-pin
  - `dcarbone/install-yq-action@v1.3.1` -> `4075b4dca348d74bd83f2bf82d30f25d7c54539b`
  - `frenck/action-yamllint@v1.5.0` -> `34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47`
  - `pnpm/action-setup@v4` -> `b906affcce14559ad1aafd4ab0e942779e9f58b1`
  - `iFaxity/wait-on-action@v1.2.1` -> `a7d13170ec542bdca4ef8ac4b15e9c6aa00a6866`
- `ci-gate.yml`: drop staged `zizmor: false`.

## Zizmor result
Against the central dryvist/.github config: **0 findings**. First-party reusable-workflow refs are all `dryvist/*@main` (trusted, suppressed). Gate should pass green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)